### PR TITLE
각 문제 별 점수를 계산해 저장할 수 있어요.

### DIFF
--- a/src/main/kotlin/kr/mashup/wequiz/application/quiz/QuizService.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/application/quiz/QuizService.kt
@@ -3,6 +3,8 @@ package kr.mashup.wequiz.application.quiz
 import kr.mashup.wequiz.config.auh.UserInfoDto
 import kr.mashup.wequiz.controller.quiz.model.CreateQuizRequest
 import kr.mashup.wequiz.controller.quiz.model.GetQuizResponse
+import kr.mashup.wequiz.controller.quiz.model.QuestionDto
+import kr.mashup.wequiz.domain.quiz.QuestionScoreCalculator
 import kr.mashup.wequiz.domain.quiz.Quiz
 import kr.mashup.wequiz.domain.quiz.option.Option
 import kr.mashup.wequiz.domain.quiz.question.Question
@@ -11,11 +13,13 @@ import kr.mashup.wequiz.repository.user.UserRepository
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.InstantSource
 
 @Service
 class QuizService(
     private val userRepository: UserRepository,
     private val quizRepository: QuizRepository,
+    private val questionsScoreCalculator: QuestionScoreCalculator,
 ) {
     @Transactional
     fun createQuiz(
@@ -28,11 +32,13 @@ class QuizService(
             title = createQuizRequest.title,
         )
 
-        val questions = createQuizRequest.questions.map { questionDto ->
+        val scores = questionsScoreCalculator.calculateScores(createQuizRequest.questions)
+        val questions = createQuizRequest.questions.mapIndexed { index, questionDto ->
             val question = Question.createNew(
                 quiz = quiz,
                 title = questionDto.title,
                 priority = questionDto.priority,
+                score = scores[index],
                 duplicatedOption = questionDto.duplicatedOption,
             )
 

--- a/src/main/kotlin/kr/mashup/wequiz/controller/quiz/model/GetQuizModel.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/controller/quiz/model/GetQuizModel.kt
@@ -12,6 +12,7 @@ data class GetQuizResponse(
         val id: Long,
         val title: String,
         val priority: Int,
+        val score: Int,
         val duplicatedOption: Boolean,
         val options: List<OptionDto>,
     ) {
@@ -21,6 +22,7 @@ data class GetQuizResponse(
                     id = question.id,
                     title = question.title,
                     priority = question.priority,
+                    score = question.score,
                     duplicatedOption = question.duplicatedOption,
                     options = question.options.map {
                         OptionDto.from(it)

--- a/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuestionScoreCalculator.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuestionScoreCalculator.kt
@@ -1,0 +1,27 @@
+package kr.mashup.wequiz.domain.quiz
+
+import kr.mashup.wequiz.controller.quiz.model.QuestionDto
+
+interface QuestionScoreCalculator {
+    fun calculateScores(questions: List<QuestionDto>): List<Int>
+}
+
+/*
+ * 단순히 총 점수 / 문제 개수 형태로 점수를 계산해요.
+ */
+class SimpleQuestionScoreCalculator: QuestionScoreCalculator {
+    override fun calculateScores(questions: List<QuestionDto>): List<Int> {
+        val totalScore = 100
+        val questionCount = questions.size
+        val score = totalScore / questionCount
+        val remainder = totalScore % questionCount
+
+        return List(questions.size) { index ->
+            if (index == questionCount - 1) {
+                score + remainder
+            } else {
+                score
+            }
+        }
+    }
+}

--- a/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuestionScoreCalculator.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuestionScoreCalculator.kt
@@ -9,7 +9,7 @@ interface QuestionScoreCalculator {
 /*
  * 단순히 총 점수 / 문제 개수 형태로 점수를 계산해요.
  */
-class SimpleQuestionScoreCalculator: QuestionScoreCalculator {
+internal class SimpleQuestionScoreCalculator: QuestionScoreCalculator {
     override fun calculateScores(questions: List<QuestionDto>): List<Int> {
         val totalScore = 100
         val questionCount = questions.size

--- a/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuizConfiguration.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/domain/quiz/QuizConfiguration.kt
@@ -1,0 +1,12 @@
+package kr.mashup.wequiz.domain.quiz
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuizConfiguration {
+    @Bean
+    fun questionScoreCalculator(): QuestionScoreCalculator {
+        return SimpleQuestionScoreCalculator()
+    }
+}

--- a/src/main/kotlin/kr/mashup/wequiz/domain/quiz/question/Question.kt
+++ b/src/main/kotlin/kr/mashup/wequiz/domain/quiz/question/Question.kt
@@ -19,6 +19,9 @@ class Question(
     @Column(name = "priority")
     val priority: Int,
 
+    @Column(name = "score")
+    val score: Int,
+
     @Column(name = "is_duplicated_Option")
     val duplicatedOption: Boolean,
 
@@ -34,12 +37,14 @@ class Question(
             quiz: Quiz,
             title: String,
             priority: Int,
+            score: Int,
             duplicatedOption: Boolean,
         ): Question {
             return Question(
                 quiz = quiz,
                 title = title,
                 priority = priority,
+                score = score,
                 duplicatedOption = duplicatedOption,
             )
         }


### PR DESCRIPTION
문제 단건 조회 시 각 문제의 점수를 알 수 있어야해요.
현재 스펙상으론 문제의 점수는 단순히 100 / 문제 개수라서, 해당 로직을 구현했어요.
각 도메인별로 configuration 관리하면 좋을 것 같아서 domain.quiz 내에 QuizConfiguration 파일 작성했는데, 너무 분리했다 싶으면 domain하위에 둬도 괜찮을 것 같아요~ 
